### PR TITLE
Error handling and log output

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,5 +36,8 @@ func main() {
 	}
 
 	log.Printf("Listening for incoming requests on TCP port '%s'...", *httpAddr)
-	http.ListenAndServe(*httpAddr, http.HandlerFunc(redirect))
+	err := http.ListenAndServe(*httpAddr, http.HandlerFunc(redirect))
+	if err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
Added log output when starting the listener, and added error handing to prevent the process exiting with no output on failure (e.g. listening on a port for which you don't have permissions)